### PR TITLE
Start the bridge server after nuxt starts.

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -23,14 +23,11 @@ const bridge = new Bridge(new Server((req, res) => {
   nuxt.server.app(req, res)
 }))
 
-bridge.server.listen({
-  host: '127.0.0.1',
-  port: nuxt.options.server.port
-})
-
-exports.launcher = bridge.launcher
-
 nuxt.ready().then(() => {
+  bridge.server.listen({
+    host: '127.0.0.1',
+    port: nuxt.options.server.port
+  })
   const hrTime = process.hrtime(startTime)
   const hrTimeMs = ((hrTime[0] * 1e9) + hrTime[1]) / 1e6
   // eslint-disable-next-line no-console
@@ -40,3 +37,5 @@ nuxt.ready().then(() => {
   console.error('λ Error while initializing nuxt:', error)
   process.exit(1)
 })
+
+exports.launcher = bridge.launcher


### PR DESCRIPTION
Addresses #20 

On cold starts, the bridge server will start on the request, but it doesn't guarantee the nuxt server has, and will often return `Cannot GET /`.  This PR fixes that. Can be tested with [nuxt-builder](https://www.npmjs.com/package/nuxt-builder)

example config for testing cold starts with  [nuxt-builder](https://www.npmjs.com/package/nuxt-builder)
```
{
  "version": 2,
  "builds": [
    { "src": "nuxt.config.js", "use": "nuxt-builder" }
  ],
  "routes": [
    { "src": "/_nuxt/.+", "headers": { "cache-control": "s-maxage=31536000" } },
    { "src": "/(.*)", "dest": "/" }
  ]
}
```