### PR TITLE
Support execution with `now dev`

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -11,7 +11,7 @@ const FileBlob = require('@now/build-utils/file-blob')
 
 const { exec, globAndPrefix, glob, preparePkgForProd, startStep, endStep } = require('./utils')
 
-async function build({ files, entrypoint, workPath, config = {} }) {
+async function build({ files, entrypoint, workPath, config = {}, meta = {} }) {
   // ----------------- Prepare build -----------------
   startStep('Prepare build')
 
@@ -30,7 +30,7 @@ async function build({ files, entrypoint, workPath, config = {} }) {
 
   // Create a real filesystem
   consola.log('Downloading files...')
-  await download(files, workPath)
+  await download(files, workPath, meta)
 
   // Change cwd to rootDir
   process.chdir(rootDir)


### PR DESCRIPTION
With a recent change to how `now dev` works, it is important to pass the provided `meta` object to the `download()` function, otherwise it attempts to overwrite the existing files in the working directory.

Related to https://spectrum.chat/zeit/now/is-it-normal-for-now-dev-to-empty-out-all-files-in-my-project~1f21924c-67c3-46d1-8771-52766c3de9ed.