### PR TITLE
feat: use `runNpmInstall` helper for install step

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -4,12 +4,16 @@ const semver = require('semver')
 const consola = require('consola')
 const esm = require('esm')
 
-const { createLambda } = require('@now/build-utils/lambda')
-const download = require('@now/build-utils/fs/download')
-const FileFsRef = require('@now/build-utils/file-fs-ref')
-const FileBlob = require('@now/build-utils/file-blob')
+const {
+  createLambda,
+  download,
+  glob,
+  runNpmInstall,
+  FileFsRef,
+  FileBlob
+} = require('@now/build-utils')
 
-const { exec, globAndPrefix, glob, preparePkgForProd, startStep, endStep } = require('./utils')
+const { exec, globAndPrefix, preparePkgForProd, startStep, endStep } = require('./utils')
 
 async function build({ files, entrypoint, workPath, config = {}, meta = {} }) {
   // ----------------- Prepare build -----------------
@@ -87,7 +91,7 @@ async function build({ files, entrypoint, workPath, config = {}, meta = {} }) {
       `--cache-folder=${yarnCacheDir}`
     ], { env: { NODE_ENV: 'development' } })
   } else {
-    await exec('npm', [ 'install' ], { env: { NODE_ENV: 'development' } })
+    await runNpmInstall(rootDir, ['--prefer-offline'])
   }
 
   // ----------------- Nuxt build -----------------


### PR DESCRIPTION
One of the issues we were running into with the builder seems to have been an issue with the NPM install command and permissions in the build process. We're deploying against a Lerna monorepo with hoisting so not a typical NPM setup.

Using the example of other builders Zeit has published, I just switched the `exec` line to use the build utilities `runNpmInstall` [helper function](https://github.com/zeit/now-builders/blob/canary/packages/now-build-utils/src/fs/run-user-scripts.ts#L117).

I left Yarn alone but it appears this helper function does take Yarn into account as well which could mean simplifying the logic above here. However, our team doesn't use Yarn so I left it alone for now since we can't reliably test the result in a production environment.