### PR TITLE
fix: pin @now/node-bridge dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release": "standard-version && git push --follow-tags && npm publish"
   },
   "dependencies": {
-    "@now/node-bridge": "^1.1.3",
+    "@now/node-bridge": "1.2.1",
     "consola": "^2.7.1",
     "esm": "^3.2.25",
     "execa": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,10 +303,10 @@
     node-fetch "2.2.0"
     yazl "2.4.3"
 
-"@now/node-bridge@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@now/node-bridge/-/node-bridge-1.1.3.tgz#e37a79dbdbeee950e07bda47efc3ab1b92313bde"
-  integrity sha512-HkKRjZr02/CgUUILbd5WkeghrsmFa767UgZMIyDyIjOKF57U0YKmL94F6KQ3UYrBpnNXvPJgqU4/jJhUdHEPkQ==
+"@now/node-bridge@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@now/node-bridge/-/node-bridge-1.2.1.tgz#9539033c849f0026bdb6a36d06b4917e24dd5ff9"
+  integrity sha512-SgofDSqQjc2nbPYz1qxjrsovU3SvYxn4zxJYzBrNA4i986aB3/zmSSEneBnDjNnjS2RsttjjhRFDBdjX5EeNEw==
 
 "@nuxtjs/eslint-config@^0.0.1":
   version "0.0.1"


### PR DESCRIPTION
This builder relies on a [private api](https://github.com/zeit/now-builders/blob/39a00c861aec7660a152c05e61ad0740295c8402/packages/now-node-bridge/src/bridge.ts#L105) of `@now/node-bridge` and some changes in `1.2.1 -> 1.2.2` broke the builder.

This PR pins the dependency to fix it.
 
Fix https://github.com/nuxt/now-builder/issues/66