### PR TITLE
feat: add support for yarn workspaces

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -82,6 +82,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
       '--frozen-lockfile',
       '--non-interactive',
       '--production=false',
+      `--modules-folder=${rootDir}/node_modules`,
       `--cache-folder=${yarnCacheDir}`
     ], spawnOpts)
   } else {
@@ -136,6 +137,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
       '--pure-lockfile',
       '--non-interactive',
       '--production=true',
+      `--modules-folder=${rootDir}/node_modules`,
       `--cache-folder=${yarnCacheDir}`
     ], spawnOpts)
   } else {


### PR DESCRIPTION
This PR adds support for projects using yarn workspaces (see #102). It forces the workspace module directory to be within the project root directory, using the `--modules-folder` options. (See https://github.com/yarnpkg/yarn/issues/6977.)

From my testing, it shouldn't break any non-workspace-based projects.