### PR TITLE
feat: expose static files as routes

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -162,6 +162,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
   startStep('Collect artifacts')
 
   // Static files
+  const useGeneratedStaticRoutes = !!config.useGeneratedStaticRoutes
   const staticFilesLambda = await globAndPrefix('**', path.join(rootDir, staticDir), 'static')
   const staticFiles = await glob('**', path.join(rootDir, staticDir))
 
@@ -189,7 +190,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
     'now__launcher.js': new FileBlob({ data: launcherSrc }),
     'now__bridge.js': new FileFsRef({ fsPath: require('@now/node-bridge') }),
     [nuxtConfigName]: new FileFsRef({ fsPath: path.resolve(rootDir, nuxtConfigName) }),
-    ...staticFilesLambda,
+    ...(!useGeneratedStaticRoutes ? staticFilesLambda : {}),
     ...serverDistFiles,
     ...nodeModules
   }
@@ -227,6 +228,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
     },
     routes: [
       { src: `/${publicPath}.+`, headers: { 'Cache-Control': 'max-age=31557600' } },
+      ...(useGeneratedStaticRoutes ? Object.keys(staticFiles).map(file => ({ src: `/${file}`, headers: { 'Cache-Control': 'max-age=31557600' } })) : []),
       { src: '/(.*)', dest: '/' }
     ]
   }

--- a/lib/build.js
+++ b/lib/build.js
@@ -178,8 +178,6 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
   startStep('Collect artifacts')
 
   // Static files
-  const useGeneratedStaticRoutes = !!config.useGeneratedStaticRoutes
-  const staticFilesLambda = await globAndPrefix('**', path.join(rootDir, staticDir), 'static')
   const staticFiles = await glob('**', path.join(rootDir, staticDir))
 
   // Client dist files
@@ -206,7 +204,6 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
     'now__launcher.js': new FileBlob({ data: launcherSrc }),
     'now__bridge.js': new FileFsRef({ fsPath: require('@now/node-bridge') }),
     [nuxtConfigName]: new FileFsRef({ fsPath: path.resolve(rootDir, nuxtConfigName) }),
-    ...(!useGeneratedStaticRoutes ? staticFilesLambda : {}),
     ...serverDistFiles,
     ...nodeModules
   }
@@ -244,7 +241,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
     },
     routes: [
       { src: `/${publicPath}.+`, headers: { 'Cache-Control': 'max-age=31557600' } },
-      ...(useGeneratedStaticRoutes ? Object.keys(staticFiles).map(file => ({ src: `/${file}`, headers: { 'Cache-Control': 'max-age=31557600' } })) : []),
+      ...Object.keys(staticFiles).map(file => ({ src: `/${file}`, headers: { 'Cache-Control': 'max-age=31557600' } })),
       { src: '/(.*)', dest: '/' }
     ]
   }


### PR DESCRIPTION
An attempt to address issue #3 and #105, by generating individual routes for each file in the `/static/` directory. To serve static files via CDN (and exclude them from the lambda), set `useGeneratedStaticRoutes` to true in the `@nuxt/now-builder` options in now.json, e.g.:

```json
  "builds": [
    {
      "src": "nuxt.config.js",
      "use": "@nuxt/now-builder",
      "config": {
        "useGeneratedStaticRoutes": true
      }
    }
  ]
```

Closes #3, #105