### PR TITLE
fix: allow installing node 10 dependencies

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -5,7 +5,7 @@ const semver = require('semver')
 const consola = require('consola')
 const esm = require('esm')
 
-const { createLambda, download, FileFsRef, FileBlob, getNodeVersion, getSpawnOptions } = require('@now/build-utils')
+const { createLambda, download, FileFsRef, FileBlob, getNodeVersion, getSpawnOptions, runNpmInstall } = require('@now/build-utils')
 
 const { exec, validateEntrypoint, globAndPrefix, glob, preparePkgForProd, startStep, endStep } = require('./utils')
 
@@ -76,7 +76,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
   // Install all dependencies
   spawnOpts.env.NODE_ENV = 'development'
   if (isYarn) {
-    await exec('yarn', [
+    await runNpmInstall(rootDir, [
       'install',
       '--prefer-offline',
       '--frozen-lockfile',
@@ -86,7 +86,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
       `--cache-folder=${yarnCacheDir}`
     ], spawnOpts)
   } else {
-    await exec('npm', [ 'install' ], spawnOpts)
+    await runNpmInstall(rootDir, [ 'install' ], spawnOpts)
   }
 
   // ----------------- Nuxt build -----------------
@@ -131,7 +131,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
 
   spawnOpts.env.NODE_ENV = 'production'
   if (isYarn) {
-    await exec('yarn', [
+    await runNpmInstall(rootDir, [
       'install',
       '--prefer-offline',
       '--pure-lockfile',
@@ -141,7 +141,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
       `--cache-folder=${yarnCacheDir}`
     ], spawnOpts)
   } else {
-    await exec('npm', [ 'install' ], spawnOpts)
+    await runNpmInstall(rootDir, [ 'install' ], spawnOpts)
   }
 
   // Validate nuxt version

--- a/lib/build.js
+++ b/lib/build.js
@@ -5,7 +5,7 @@ const semver = require('semver')
 const consola = require('consola')
 const esm = require('esm')
 
-const { createLambda, download, FileFsRef, FileBlob, getNodeVersion, getSpawnOptions, runNpmInstall } = require('@now/build-utils')
+const { createLambda, download, FileFsRef, FileBlob, getNodeVersion, getSpawnOptions } = require('@now/build-utils')
 
 const { exec, validateEntrypoint, globAndPrefix, glob, preparePkgForProd, startStep, endStep } = require('./utils')
 
@@ -76,7 +76,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
   // Install all dependencies
   spawnOpts.env.NODE_ENV = 'development'
   if (isYarn) {
-    await runNpmInstall(rootDir, [
+    await exec('yarn', [
       'install',
       '--prefer-offline',
       '--frozen-lockfile',
@@ -86,7 +86,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
       `--cache-folder=${yarnCacheDir}`
     ], spawnOpts)
   } else {
-    await runNpmInstall(rootDir, [ 'install' ], spawnOpts)
+    await exec('npm', [ 'install' ], spawnOpts)
   }
 
   // ----------------- Nuxt build -----------------
@@ -113,7 +113,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
     '--standalone',
     '--no-lock', // #19
     `--config-file "${nuxtConfigName}"`
-  ])
+  ], spawnOpts)
 
   // ----------------- Install dependencies -----------------
   startStep('Install dependencies')
@@ -131,7 +131,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
 
   spawnOpts.env.NODE_ENV = 'production'
   if (isYarn) {
-    await runNpmInstall(rootDir, [
+    await exec('yarn', [
       'install',
       '--prefer-offline',
       '--pure-lockfile',
@@ -141,7 +141,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
       `--cache-folder=${yarnCacheDir}`
     ], spawnOpts)
   } else {
-    await runNpmInstall(rootDir, [ 'install' ], spawnOpts)
+    await exec('npm', [ 'install' ], spawnOpts)
   }
 
   // Validate nuxt version

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,10 +8,10 @@ async function exec (cmd, args, { env, ...opts } = {}) {
 
   consola.log('Running', cmd, ...args)
 
-  await execa(cmd, args, {
+  await execa('npx', [cmd, ...args], {
     stdout: process.stdout,
     stderr: process.stderr,
-    preferLocal: true,
+    preferLocal: false,
     env: {
       MINIMAL: 1,
       NODE_OPTIONS: '--max_old_space_size=3000',


### PR DESCRIPTION
This pull request follows the pattern of the `@now/node` builder to allow installing packages that require Node 10. (This will fix #101, for example.)

However, I'm still struggling with packages like `node-sass` that complain about mismatches of bindings at build-time. The Node 10 bindings are installed correctly, but the `nuxt build` process seems to be using Node 8. My operating hypothesis is that the builder itself is being run by Node 8 - but I'd welcome any help to diagnose or solve.

Closes #101, see also #74.