### PR TITLE
feat: add required options for typescript projects

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -41,6 +41,22 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
   const nodeVersion = await getNodeVersion(rootDir)
   const spawnOpts = getSpawnOptions(meta, nodeVersion)
 
+  const usesTypescript = pkg.dependencies.includes('@nuxt/typescript-build') || pkg.dependencies.includes('@nuxt/typescript')
+  if (usesTypescript) {
+    spawnOpts.env.NODE_PRESERVE_SYMLINKS = 1
+  }
+
+  if (usesTypescript && (await fs.exists('tsconfig.json'))) {
+    let tsConfig
+    try {
+      tsConfig = await fs.readJson('tsconfig.json')
+    } catch (e) {
+      throw new Error(`Can not read tsconfig.json from ${rootDir}`)
+    }
+    tsConfig.exclude = [ ...tsConfig.exclude, 'node_modules_dev', 'node_modules_prod' ]
+    await fs.writeJSON('tsconfig.json', tsConfig)
+  }
+
   // Detect npm (prefer yarn)
   const isYarn = !await fs.exists('package-lock.json')
   consola.log('Using', isYarn ? 'yarn' : 'npm')


### PR DESCRIPTION
This PR aims to implement the required changes to `tsconfig.json` and `now.json` for Typescript based builds (as mentioned in #28), to make it easier to set up a Typescript project using now-builder (as long as the project doesn't use TS nuxt.config.ts, local modules or serverMiddlewares).