### PR TITLE
fix: use new object property from Now

### DIFF
--- a/lib/prepare-cache.js
+++ b/lib/prepare-cache.js
@@ -3,10 +3,10 @@ const fs = require('fs-extra')
 const consola = require('consola')
 const { glob, startStep, endStep } = require('./utils')
 
-async function prepareCache ({ cachePath, workPath, entrypoint }) {
+async function prepareCache ({ prepareCachePath, workPath, entrypoint }) {
   const entryDir = path.dirname(entrypoint)
   const rootDir = path.join(workPath, entryDir)
-  const cacheDir = path.join(cachePath, entryDir)
+  const cacheDir = path.join(prepareCachePath, entryDir)
 
   consola.log('Cache dir:', cacheDir)
 

--- a/test/utils/run-build-lambda.js
+++ b/test/utils/run-build-lambda.js
@@ -43,7 +43,7 @@ async function runBuildLambda (inputPath) {
   })
 
   const cacheResult = await wrapper.prepareCache({
-    cachePath: path.join(workPath, '.cache'),
+    prepareCachePath: path.join(workPath, '.cache'),
     workPath,
     entrypoint
   })


### PR DESCRIPTION
(It looks like Now silently changed the name of the cache directory from `cachePath` to `prepareCachePath`.)

Closes #111