### PR TITLE
fix: consume default export of nuxt config file

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -111,7 +111,7 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
   // Read nuxt.config.js
   const _esm = esm(module)
   const nuxtConfigName = 'nuxt.config.js'
-  const nuxtConfigFile = _esm(path.resolve(rootDir, nuxtConfigName))
+  const nuxtConfigFile = _esm(path.resolve(rootDir, nuxtConfigName)).default || _esm(path.resolve(rootDir, nuxtConfigName))
 
   // Read options from nuxt.config.js otherwise set sensible defaults
   const staticDir = (nuxtConfigFile.dir && nuxtConfigFile.dir.static) ? nuxtConfigFile.dir.static : 'static'

--- a/lib/build.js
+++ b/lib/build.js
@@ -111,7 +111,8 @@ async function build ({ files, entrypoint, workPath, config = {}, meta = {} }) {
   // Read nuxt.config.js
   const _esm = esm(module)
   const nuxtConfigName = 'nuxt.config.js'
-  const nuxtConfigFile = _esm(path.resolve(rootDir, nuxtConfigName)).default || _esm(path.resolve(rootDir, nuxtConfigName))
+  let nuxtConfigFile = _esm(path.resolve(rootDir, nuxtConfigName))
+  nuxtConfigFile = nuxtConfigFile.default || nuxtConfigFile
 
   // Read options from nuxt.config.js otherwise set sensible defaults
   const staticDir = (nuxtConfigFile.dir && nuxtConfigFile.dir.static) ? nuxtConfigFile.dir.static : 'static'


### PR DESCRIPTION
Closes #43 (custom buildPath wasn't being read)

It's possible this may also fix the following reports of 404s:
* https://github.com/nuxt/now-builder/issues/111#issuecomment-529700371
* https://github.com/nuxt/now-builder/pull/106#issuecomment-526937176