### PR TITLE
fix: prepare cache against workCache

### DIFF
--- a/src/prepare-cache.ts
+++ b/src/prepare-cache.ts
@@ -6,7 +6,7 @@ import consola from 'consola'
 import { startStep, endStep } from './utils'
 
 // Amend below line once https://github.com/zeit/now/issues/2992 is resolved
-async function prepareCache({ workPath, entrypoint }: PrepareCacheOptions): Promise<Record<string, FileRef>> {
+async function prepareCache ({ workPath, entrypoint }: PrepareCacheOptions): Promise<Record<string, FileRef>> {
   const entryDir = path.dirname(entrypoint)
 
   startStep('Collect cache')

--- a/src/prepare-cache.ts
+++ b/src/prepare-cache.ts
@@ -6,29 +6,18 @@ import consola from 'consola'
 import { startStep, endStep } from './utils'
 
 // Amend below line once https://github.com/zeit/now/issues/2992 is resolved
-async function prepareCache ({ cachePath, workPath, entrypoint }: PrepareCacheOptions): Promise<Record<string, FileRef>> {
+async function prepareCache({ workPath, entrypoint }: PrepareCacheOptions): Promise<Record<string, FileRef>> {
   const entryDir = path.dirname(entrypoint)
-  const rootDir = path.join(workPath, entryDir)
-  const cacheDir = path.join(cachePath, entryDir)
-
-  consola.log('Cache dir:', cacheDir)
-
-  startStep('Clean cache')
-  await fs.remove(cacheDir)
-  await fs.mkdirp(cacheDir)
-  endStep()
 
   startStep('Collect cache')
   const cache: Record<string, FileRef> = {}
   for (const dir of ['.now_cache', 'node_modules_dev', 'node_modules_prod']) {
-    const src = path.join(rootDir, dir)
-    const dst = path.join(cacheDir, dir)
-    if (!fs.existsSync(src)) {
-      consola.warn(src, 'not exists. skipping!')
+    const activeDirectory = path.join(workPath, entryDir, dir)
+    if (!fs.existsSync(activeDirectory)) {
+      consola.warn(activeDirectory, 'not exists. skipping!')
       continue
     }
-    await fs.rename(src, dst)
-    const files = await glob(path.join(dir, '**'), cacheDir)
+    const files = await glob(path.join(entryDir, dir, '**'), workPath)
     consola.info(`${Object.keys(files).length} files collected from ${dir}`)
     Object.assign(cache, files)
   }


### PR DESCRIPTION
Now have changed their requirements for the cache. It now must be built relative to `workPath` or `prepareCachePath`. This PR implements this.

In addition, it no longer creates or copies files into the cache directory, as Now do this step subsequent to the running of `prepareCache`.

Closes #133