### PR TITLE
feat: add support for now-build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ The Node.js version used is the latest 8.10.x release. Alternatively, you can sp
 
 **Note that Nuxt 2.11+ requires Node 10+.**
 
+### `now-build` script support
+
+This builder will run a given [custom build step](https://zeit.co/docs/runtimes/?query=now-build#advanced-usage/advanced-node-js-usage/custom-build-step-for-node-js) if you have added a `now-build` key under `scripts` in `package.json`.
+
 ## Troubleshooting
 
 ### Environment variables

--- a/src/build.ts
+++ b/src/build.ts
@@ -104,6 +104,22 @@ export async function build ({ files, entrypoint, workPath, config = {}, meta = 
     await exec('npm', ['install'], { ...spawnOpts, env: { ...spawnOpts.env, NODE_ENV: 'development' } })
   }
 
+  // ----------------- Pre build -----------------
+  if (pkg.scripts && Object.keys(pkg.scripts).includes('now-build')) {
+    startStep('Pre build')
+    const command = pkg.scripts['now-build']
+    if (isYarn) {
+      await exec('yarn', [
+        'now-build'
+      ], spawnOpts)
+    } else {
+      await exec('npm', [
+        'run',
+        'now-build'
+      ], spawnOpts);
+    }
+  }
+
   // ----------------- Nuxt build -----------------
   startStep('Nuxt build')
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -107,7 +107,6 @@ export async function build ({ files, entrypoint, workPath, config = {}, meta = 
   // ----------------- Pre build -----------------
   if (pkg.scripts && Object.keys(pkg.scripts).includes('now-build')) {
     startStep('Pre build')
-    const command = pkg.scripts['now-build']
     if (isYarn) {
       await exec('yarn', [
         'now-build'
@@ -116,7 +115,7 @@ export async function build ({ files, entrypoint, workPath, config = {}, meta = 
       await exec('npm', [
         'run',
         'now-build'
-      ], spawnOpts);
+      ], spawnOpts)
     }
   }
 

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -16,7 +16,8 @@ it('Should build the standard example', async () => {
   // Build files
   const buildFiles = [
     'test.txt',
-    '_nuxt/LICENSES'
+    '_nuxt/LICENSES',
+    'now-build'
   ]
   for (const file of buildFiles) {
     expect(output[file]).toBeDefined()

--- a/test/fixture/www/package.json
+++ b/test/fixture/www/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
   "license": "MIT",
+  "scripts": {
+    "now-build": "echo 1 > static/now-build"
+  },
   "devDependencies": {
     "nuxt": "2.10.0"
   }


### PR DESCRIPTION
If you have been using the `now-node` runtime, you will be familiar
with the `now-build` script. This PR adds support for a prebuild script
using the [same syntax](https://zeit.co/docs/runtimes/?query=now-build#advanced-usage/advanced-node-js-usage/custom-build-step-for-node-js).