### PR TITLE
docs: fix typo in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Then define the build in `now.json`:
   "builds": [
     {
       "src": "nuxt.config.js",
-      "use": "@nuxtjs/now-builder
+      "use": "@nuxtjs/now-builder"
     }
   ]
 }


### PR DESCRIPTION
The first example of a now.json config did not include a closing quote. This has now been rectified.